### PR TITLE
Tables can now be generated from nested data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'text-table'
-gem 'cog-rb', '~> 0.1.5'
+gem 'cog-rb', '~> 0.1.6'
+gem 'jsonpath', '~> 0.5.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'text-table'
-gem 'cog-rb', '~> 0.1.6'
+gem 'cog-rb', '~> 0.1.7'
 gem 'jsonpath', '~> 0.5.8'
+
+group "development", "test" do
+  gem "rspec"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cog-rb (0.1.5)
+    cog-rb (0.1.6)
+    jsonpath (0.5.8)
+      multi_json
+    multi_json (1.12.1)
     text-table (1.2.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cog-rb (~> 0.1.5)
+  cog-rb (~> 0.1.6)
+  jsonpath (~> 0.5.8)
   text-table
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cog-rb (0.1.6)
+    cog-rb (0.1.7)
+    diff-lcs (1.2.5)
     jsonpath (0.5.8)
       multi_json
     multi_json (1.12.1)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     text-table (1.2.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cog-rb (~> 0.1.6)
+  cog-rb (~> 0.1.7)
   jsonpath (~> 0.5.8)
+  rspec
   text-table
 
 BUNDLED WITH

--- a/config.yaml
+++ b/config.yaml
@@ -2,10 +2,10 @@
 cog_bundle_version: 3
 name: format
 description: "Pipeline output formatting utilities"
-version: "0.3"
+version: "0.4.0"
 docker:
   image: cogcmd/format
-  tag: "0.3"
+  tag: "0.4.0"
 commands:
   head:
     executable: /home/bundle/cog-command
@@ -34,7 +34,89 @@ commands:
   table:
     description: "Generate a table from pipeline output"
     executable: /home/bundle/cog-command
-    documentation: "format:table field1 field2 ... fieldN - format the output of the previous pipeline stage as a table"
+    documentation: |
+      format:table field1 field2 ... fieldN - format the output of the previous pipeline stage as a table
+
+      Each field is taken to be a key that should be extracted from an
+      input map.
+
+      When the field is a string like "foo", this means "select the
+      value of the 'foo' key".
+
+      Alternatively, a path can be provided, as in "foo.bar.baz". This
+      will produce a column named "baz", with values found at that key
+      path. For instance, when run on the object
+
+        {"foo": {"bar": {"baz": "hello world"}}}
+
+      the string "foo.bar.baz" will extract the value
+      "hello world".
+
+      Fields may be renamed, as well. Passing a quoted string like
+      "foo=bar" will produce a column labeled "foo", with the value of
+      the "bar" key. Paths can be renamed in the same way, if desired
+      (e.g. "foo=foo.bar.baz"). Note that these pairs *must* be quoted
+      to parse correctly.
+
+      If such a column name transformation will result in a duplicate
+      name, the full keypath will be used instead.
+
+      However, these conventions mean that this command may not
+      operate well on fields that contain "=" or "." characters.
+
+      These behaviors are demonstrated in the following examples,
+      formatted for readability:
+
+      seed '[{"foo": "hello", "bar": "world"},
+             {"foo": "hola", "bar": "mundo"}]'
+        | format:table foo bar
+      +-------+-------+
+      |  foo  |  bar  |
+      +-------+-------+
+      | hello | world |
+      | hola  | mundo |
+      +-------+-------+
+
+      seed '[{"foo": "hello", "bar": "world"},
+             {"foo": "hola", "bar": "mundo"}]'
+        | format:table "key=foo" "value=bar"
+      +-------+-------+
+      |  key  | value |
+      +-------+-------+
+      | hello | world |
+      | hola  | mundo |
+      +-------+-------+
+
+      seed '[{"foo": {"greeting": "hello", "valediction": "good-bye"}, "bar": "world"},
+             {"foo": {"greeting": "hola", "valediction": "adios"}, "bar": "mundo"}]'
+        | format:table foo.greeting bar
+
+      +----------+-------+
+      | greeting |  bar  |
+      +----------+-------+
+      | hello    | world |
+      | hola     | mundo |
+      +----------+-------+
+
+      seed '[{"foo": {"greeting": "hello", "valediction": "good-bye"}, "bar": "world"},
+             {"foo": {"greeting": "hola", "valediction": "adios"}, "bar": "mundo"}]'
+        | format:table "farwell=foo.valediction" bar
+      +----------+-------+
+      | farwell  |  bar  |
+      +----------+-------+
+      | good-bye | world |
+      | adios    | mundo |
+      +----------+-------+
+
+      seed '[{"foo": {"bar": "inside"}, "bar": "outside"},
+             {"foo": {"bar": "also inside"}, "bar": "also outside"}]'
+        | format:table bar foo.bar
+      +--------------+-------------+
+      |     bar      |   foo.bar   |
+      +--------------+-------------+
+      | outside      | inside      |
+      | also outside | also inside |
+      +--------------+-------------+
     rules: [ 'allow' ]
 templates:
   preformatted:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'cog'
+require 'rspec/cog'
+
+RSpec.configure do |config|
+  config.include Cog::RSpec::Setup
+end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+
+describe "The format:table command" do
+  let(:command_name) { "table" }
+
+    context "on the final invocation" do
+      before(:each) { ENV["COG_INVOCATION_STEP"] = "last" }
+
+      let(:cog_env) do
+        [
+          {"hello" => "world", "goodbye" => "cruel world"},
+          {"hello" => "mundo", "outer" => {"middle" => {"inner" => "sanctum"}}},
+          {"hello" => "monde", "outer" => {"inside" => "yay"}}
+        ]
+      end
+
+      it "makes a simple table" do
+        run_command(args: ["hello"])
+        expect(command).to respond_with_text(<<eom)
++-------+
+| hello |
++-------+
+| world |
+| mundo |
+| monde |
++-------+
+eom
+      end
+
+      it "handles inputs that don't have a given field" do
+        run_command(args: ["hello", "goodbye"])
+        expect(command).to respond_with_text(<<eom)
++-------+-------------+
+| hello |   goodbye   |
++-------+-------------+
+| world | cruel world |
+| mundo |             |
+| monde |             |
++-------+-------------+
+eom
+      end
+
+      it "can rename top-level fields" do
+        run_command(args: ["planet=hello"])
+        expect(command).to respond_with_text(<<eom)
++--------+
+| planet |
++--------+
+| world  |
+| mundo  |
+| monde  |
++--------+
+eom
+      end
+
+      it "can extract nested data" do
+        run_command(args: ["outer.middle.inner"])
+        expect(command).to respond_with_text(<<eom)
++---------+
+|  inner  |
++---------+
+|         |
+| sanctum |
+|         |
++---------+
+eom
+      end
+
+      it "can rename nested data" do
+        run_command(args: ["latin=outer.middle.inner"])
+        expect(command).to respond_with_text(<<eom)
++---------+
+|  latin  |
++---------+
+|         |
+| sanctum |
+|         |
++---------+
+eom
+      end
+
+      it "conflicting renames show full path when conflict comes later" do
+        run_command(args: ["hello", "hello=outer.middle.inner"])
+        expect(command).to respond_with_text(<<eom)
++-------+--------------------+
+| hello | outer.middle.inner |
++-------+--------------------+
+| world |                    |
+| mundo | sanctum            |
+| monde |                    |
++-------+--------------------+
+eom
+      end
+
+      it "conflicting renames show full path when conflict comes first" do
+        run_command(args: ["hello=outer.middle.inner", "hello"])
+        expect(command).to respond_with_text(<<eom)
++--------------------+-------+
+| outer.middle.inner | hello |
++--------------------+-------+
+|                    | world |
+| sanctum            | mundo |
+|                    | monde |
++--------------------+-------+
+eom
+      end
+
+      it "full paths are only shown for conflictingly-named columns" do
+        run_command(args: ["hello=outer.middle.inner", "outer.inside", "hello"])
+        expect(command).to respond_with_text(<<eom)
++--------------------+--------+-------+
+| outer.middle.inner | inside | hello |
++--------------------+--------+-------+
+|                    |        | world |
+| sanctum            |        | mundo |
+|                    | yay    | monde |
++--------------------+--------+-------+
+eom
+      end
+    end
+
+end


### PR DESCRIPTION
Previously, the `table` command could only extract data from top-level
map keys. Now, it can extract data from nested data structures with the
addition of some JSONPath smarts.

Details about the change can be found in the command documentation in
`config.yaml`.

Fixes operable/cog#784
